### PR TITLE
feat: Add an encapsulated docker-compose based demonstration of EngFlow Free Tier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# IDE files
+.idea/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ protocol clients such as [Bazel](https://bazel.build).
 EngFlow Free Tier may be used a remote cache and UI for any Bazel build. It can
 also execute remote actions in a Linux Docker container.
 
-## Getting started
+## Getting Started
 
 EngFlow Free Tier is distributed as a Docker image for x86_64 Linux. The images
 are hosted by the [GitHub container
@@ -42,6 +42,23 @@ usecases, an image may be passed via Bazel's `--remote_default_exec_properties`
 flag. For instance,
 `--remote_default_exec_properties=container-image=docker://docker.io/ubuntu:focal-20210827`
 to run remote actions in a recent Ubuntu container.
+
+## Getting Started w/ Docker Compose
+
+EngFlow Free Tier may be started as a service through Docker Compose.  A sample configuration of EngFlow 
+deployed as a service is demonstrated in the ```docker-compose.yml``` file included in this repository.
+The example demonstrates the configuration of the EngFlow remote execution service to use containers for
+both local execution and remote runtime workers.
+
+To start the EngFlow Free Tier and run build targets from the EngFlow example project, simply execute the 
+following command from the top-level directory of this repository:
+
+```commandline
+docker-compose up
+```
+
+EngFlow Free Tier can be deployed easily to various cloud providers through Docker Compose or directly as a container
+through Kubernetes, Amazon ECS, Azure Container Apps, Google Cloud Run and any other OCI-compatible container platform.
 
 ## Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3"
+services:
+
+  engflow:
+    image: ghcr.io/engflow/free:2.8.0
+    container_name: engflow
+    environment:
+      - DATA_DIR=/tmp/engflow_data
+    ports:
+      - "8080:8080"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/tmp/engflow_data:/tmp/engflow_data"
+
+  registry:
+    network_mode: host
+    image: registry:2
+    environment:
+      REGISTRY_HTTP_ADDR: 0.0.0.0:5443
+      REGISTRY_AUTH: htpasswd
+      REGISTRY_AUTH_HTPASSWD_REALM: Registry
+      REGISTRY_AUTH_HTPASSWD_PATH: /auth/.htpasswd
+    volumes:
+      - ./registry/certs:/certs
+      - ./registry/auth:/auth
+
+  example:
+    network_mode: host
+    build:
+      context: .
+      dockerfile: ./example/Dockerfile
+
+    depends_on:
+      - registry
+      - engflow
+    volumes:
+      - ./example/etc/docker/certs.d:/etc/docker/certs.d
+      - ./registry/certs:/certs
+      - /var/run/docker.sock:/var/run/docker.sock
+
+networks:
+  engflow: {}

--- a/example/.bazelrc
+++ b/example/.bazelrc
@@ -1,0 +1,5 @@
+build:engflow --remote_executor=grpc://localhost:8080
+build:engflow --remote_cache=grpc://localhost:8080
+build:engflow --bes_backend=grpc://localhost:8080
+build:engflow --bes_results_url=http://localhost:8080/invocation/
+build:engflow --remote_default_exec_properties=container-image=localhost:5443/engflow/worker

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:latest
+
+WORKDIR /home/engflow
+
+RUN <<-EOF
+    apt-get update
+    apt-get install -y build-essential python3 default-jdk git curl node.js npm
+    curl -sSL https://get.docker.com/ | sh
+EOF
+
+RUN npm install -g @bazel/bazelisk
+
+RUN git clone https://github.com/EngFlow/example.git
+
+COPY ./example/.bazelrc ./example/engflow.bazelrc
+COPY ./example/entrypoint.sh ./example/entrypoint.sh
+COPY ./worker/Dockerfile ./worker/Dockerfile
+
+ENTRYPOINT chmod +x ./example/entrypoint.sh && ./example/entrypoint.sh
+

--- a/example/entrypoint.sh
+++ b/example/entrypoint.sh
@@ -5,7 +5,6 @@ docker login -u=engflow -p=engflow localhost:5443
 docker build ./worker -t localhost:5443/engflow/worker:latest
 docker push localhost:5443/engflow/worker
 
-# echo curl -v -u engflow:engflow https://host.docker.internal:5043/v2/
-
 pushd /home/engflow/example || exit 1
+bazel clean
 bazel --bazelrc=engflow.bazelrc build //cpp/... --config=engflow

--- a/example/entrypoint.sh
+++ b/example/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+sleep 5
+docker login -u=engflow -p=engflow localhost:5443
+docker build ./worker -t localhost:5443/engflow/worker:latest
+docker push localhost:5443/engflow/worker
+
+# echo curl -v -u engflow:engflow https://host.docker.internal:5043/v2/
+
+pushd /home/engflow/example || exit 1
+bazel --bazelrc=engflow.bazelrc build //cpp/... --config=engflow

--- a/registry/auth/.htpasswd
+++ b/registry/auth/.htpasswd
@@ -1,0 +1,2 @@
+engflow:$2y$05$LeRPdCm7WTNdRdWG/xd22Oli2kN.bfTyufEwEyhh1A/LFrx0d.oFe
+

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y build-essential python3 default-jdk


### PR DESCRIPTION
The EngFlow Free Tier requires some basic configuration to function properly including configuration of compatible host and target environments which utilize Bazel's platform and toolchain support.  The example deployment of the docker-compose based project added by this pull requests captures the "plumbing" required to deploy the EngFlow Free Tier, configure a worker container and configure a compatible host environment which can execute a Bazel build using EngFlow.

This example can later be extended to demonstrate various means of deploying, configuring and testing EngFlow Free Tier including the ability to deploy the free tier directly to Amazon ECS using Docker Compose or Copilot.